### PR TITLE
Change mp_maxrounds to 24

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project does not adhere to Semantic Versioning.
 
 ## [Unreleased]
+### Changed
+* `cvars.mp_maxrounds` now defaults to `24`, which is the default value in CS2
 
 
 # [2.2.0] - 2023-11-22

--- a/src/themes/raw/theme.json
+++ b/src/themes/raw/theme.json
@@ -22,7 +22,7 @@
 
 		"cvars.mp_maxrounds": {
 			"type": "number",
-			"fallback": 30,
+			"fallback": 24,
 			"section": "Cvars",
 			"label": "Value of mp_maxrounds, i.e. the maximum number of rounds played in regulation"
 		},


### PR DESCRIPTION
The new default mp_maxrounds in CS2 is 24