### PR TITLE
Three (3) tactical timeouts as default

### DIFF
--- a/src/themes/fennec/theme.json
+++ b/src/themes/fennec/theme.json
@@ -200,7 +200,7 @@
 
 		"cvars.mp_team_timeout_max": {
 			"type": "number",
-			"fallback": 4,
+			"fallback": 3,
 			"section": "Cvars",
 			"label": "Value of mp_team_timeout_max, i.e. the number of tactical timeouts available per team"
 		},


### PR DESCRIPTION
Many tournament organizers have three (3) tactical timeouts as default. The small TO's just copy their rules.

For example ESL:
https://pro.eslgaming.com/tour/2023/10/esl-pro-tour-fall-2023-rule-book-update/