### PR TITLE
Added ability to automatically hide players with "coach" in their name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project does not adhere to Semantic Versioning.
 
 ## [Unreleased]
+### Added
+* Added `teams.hideCoachesByName` option (disabled by default), which hides any player that has the word `coach` in their name
 
 
 ## [2.6.2] - 2025-07-05

--- a/docs/hiding-players.md
+++ b/docs/hiding-players.md
@@ -11,4 +11,6 @@ Provide one player per line.
 If you use a player's name, you'll need to exactly match the name that would otherwise be displayed by the HUD.
 If you've changed their name using [Player Name Overrides](https://github.com/drweissbrot/cs-hud/blob/master/docs/player-name-overrides.md), use the name that you used for the override.
 
-You can also enable the `teams.autoHideCoaches` option to automatically hide any player whose nickname contains "coach" (case-insensitive). This will hide coaches without the need to add them manually to the list above. Use carefully - will hide real players if they have "coach" in their name.
+You can also enable the `teams.hideCoachesByName` option to automatically hide any player whose nickname contains the word `coach` (case-insensitive).
+This will hide coaches without the need to add them manually to the list above.
+Use carefully, as it will also hide real players if they have `coach` in their name.

--- a/src/themes/raw/gsi/parse-players.js
+++ b/src/themes/raw/gsi/parse-players.js
@@ -56,17 +56,16 @@ const parsePlayerWeapons = (player) => Object.values(player.weapons).flatMap((we
 export const parsePlayers = () => {
 	const playerNameOverrides = getPlayerNameOverrides()
 	const { hiddenPlayerNames, hiddenPlayerSteam64Ids } = getHiddenPlayers()
+	const hideCoachesByName = options['teams.hideCoachesByName']
 
 	const players = []
-	const autoHideCoaches = options['teams.autoHideCoaches']
 
 	for (const [steam64Id, player] of Object.entries(gsiState.allplayers)) {
 		if (hiddenPlayerSteam64Ids.has(steam64Id)) continue
 
 		const name = playerNameOverrides.get(steam64Id) || player.name
 		if (hiddenPlayerNames.has(name)) continue
-
-		if (autoHideCoaches && /coach/i.test(name)) continue
+		if (hideCoachesByName && /\bcoach\b/i.test(name)) continue
 
 		const observerSlot = getObserverSlot(player, steam64Id)
 		if (observerSlot === undefined) continue

--- a/src/themes/raw/theme.json
+++ b/src/themes/raw/theme.json
@@ -52,10 +52,10 @@
 			"label": "List of names or SteamID64s of players that should not be shown in the HUD (e.g. coaches); see https://github.com/drweissbrot/cs-hud/blob/master/docs/hiding-players.md"
 		},
 
-		"teams.autoHideCoaches": {
+		"teams.hideCoachesByName": {
 			"type": "boolean",
 			"section": "Teams",
-			"label": "Hides all playes who has \"coach\" in their nickname (in any form); see https://github.com/drweissbrot/cs-hud/blob/master/docs/hiding-players.md"
+			"label": "Hide all playes who have the word \"coach\" in their nickname; see https://github.com/drweissbrot/cs-hud/blob/master/docs/hiding-players.md"
 		}
 	}
 }


### PR DESCRIPTION
### Pretty self-explanatory: here is before and after:
<img width="1667" height="882" alt="image" src="https://github.com/user-attachments/assets/4f64c57a-187c-433d-90c1-7aa382dcaafe" />
<img width="1670" height="882" alt="image" src="https://github.com/user-attachments/assets/9e0a27d4-28eb-4ffd-9674-2ccf5d695d47" />

### And this is what config option looks like now:
<img width="1636" height="719" alt="image" src="https://github.com/user-attachments/assets/90ecf827-e9f7-41b0-a0a9-c57167fd7a23" />

I think `getPlayerNameOverrides` puts "Coach|" in the beginning of the name, so it works nicely with official matches  